### PR TITLE
Add delay for container creation

### DIFF
--- a/src/main/java/com/github/tomaskir/netxms/csvimporter/netxms/NetxmsConnector.java
+++ b/src/main/java/com/github/tomaskir/netxms/csvimporter/netxms/NetxmsConnector.java
@@ -61,7 +61,6 @@ public final class NetxmsConnector {
                     return object.getObjectClass() == AbstractObject.OBJECT_CONTAINER && object.getObjectName().equals(node.getContainer());
                 }
             };
-
             // find node's container
             AbstractObject container = nxcSession.findObject(filter);
             if (container == null) {
@@ -75,6 +74,13 @@ public final class NetxmsConnector {
                     // create container
                     objectCreationData = new NXCObjectCreationData(AbstractObject.OBJECT_CONTAINER, node.getContainer(), INFRASTRUCTURE_SERVICES_ID);
                     nodeParentId = nxcSession.createObject(objectCreationData);
+                    //Add delay of 1 second before creating. Fixes issue with duplicate containers.
+                    try{
+                        Thread.sleep(1000);
+                    }
+                    catch(InterruptedException ex){
+                        Thread.currentThread().interrupt();
+                    }
                 }
             } else {
                 // if found, use it as node's parent


### PR DESCRIPTION
Problem:
Have 5 nodes in nodes.csv with 3 binding to "Container1" and 2 binding to  "Container2".
Calling script creates 3 containers called "Container1" and 2 containers called "Container2" instead of detecting duplicates.

The above occurs when 2 or more nodes with the same container binding are processed in quick succession, the duplicity check on the second node returns null because NetXMS Server hasn't yet registered the previous container properly. Adding a short delay after a new container is created ensures that when the next node is processed the duplicate check works as expected.