### PR TITLE
Update all dependencies, bump major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.tomaskir</groupId>
     <artifactId>netxms-csv-importer</artifactId>
-    <version>2.1.4</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 
     <groupId>com.github.tomaskir</groupId>
     <artifactId>netxms-csv-importer</artifactId>
-    <version>1.1.4</version>
+    <version>2.1.4</version>
     <packaging>jar</packaging>
 
     <properties>
         <source.encoding>utf-8</source.encoding>
-        <java.version>1.7</java.version>
-        <lombok.version>1.16.10</lombok.version>
-        <netxms-client.version>3.7.92</netxms-client.version>
+        <java.version>11</java.version>
+        <lombok.version>1.18.24</lombok.version>
+        <netxms-client.version>4.2.395</netxms-client.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This PR will update the Java version to 11, NXMS client to 4.2.395, Lombok to 1.18.24. Major version bump due to a large version gap since last update of the NXMS library